### PR TITLE
tracker: improve rendering performance

### DIFF
--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -14,7 +14,7 @@
 @links
   https://github.com/joepvanlier/Hackey-Trackey
 @license MIT
-@version 3.09
+@version 3.10
 @screenshot https://i.imgur.com/c68YjMd.png
 @about
   ### Hackey-Trackey
@@ -45,7 +45,7 @@
 
 --[[
  * Changelog:
- + v3.10 (t.b.d.)
+ + v3.10 (2023-01-01)
   + Fix bug to support gfx2imgui.
   + Move keyboard input handling out of main update loop for clarity.
   + Add some commented out functions used for profiling stuff.
@@ -53,7 +53,7 @@
   + Rename render function.
   + Change OFC to OFF in pattern data.
   + Add protracker inspired theme (TonE).
-  + Add cached render mode for pattern data (better gfx performance).
+  + Add cached render mode for pattern data (better gfx performance). Note, if you find issues with it, please let me know and disable it in the options for now.
  * v3.09 (2022-11-24)
   + Improve layout logic.
   + Add scrollbar to options.
@@ -631,7 +631,7 @@
 -- gfx = dofile(reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/gfx2imgui.lua')
 
 tracker = {}
-tracker.name = "Hackey Trackey v3.09"
+tracker.name = "Hackey Trackey v3.10"
 
 tracker.configFile = "_hackey_trackey_options_.cfg"
 tracker.keyFile = "userkeys.lua"

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -52,6 +52,7 @@
   + Fix nil bug when simulating.
   + Rename render function.
   + Change OFC to OFF in pattern data.
+  + Add protracker inspired theme (TonE).
  * v3.09 (2022-11-24)
   + Improve layout logic.
   + Add scrollbar to options.
@@ -900,7 +901,7 @@ tracker.binaryOptions = {
     { 'channelOffset', 'Make channel number reflect midi chan' },
     }
 
-tracker.colorschemes = {"default", "buzz", "it", "hacker", "renoise", "renoiseB", "buzz2", "sink"}
+tracker.colorschemes = {"default", "buzz", "it", "hacker", "renoise", "renoiseB", "buzz2", "sink", "TonE"}
 
 noteNames = {}
 
@@ -1294,6 +1295,85 @@ function tracker:loadColors(colorScheme)
   LENGHT text color = RGB(52,160,232)
   If possible : background line3 (every 8 steps) = RGB(179,179,179)]]--
   
+  elseif colorScheme == "TonE" then
+    tracker:loadColors("renoise")  -- Load some defaults
+    local protracker_blue = {51/256, 68/256, 255/256, 1}
+    local protracker_yellow = {255/256, 221/256, 0/256, 1}
+    
+    self.colors.ellipsis         = 0  -- Draw ellipses instead of dots
+    self.colors.shadercolor      = {255/256, 221/256, 0/256, 1}
+    
+    -- bar numbers, note numbers
+    self.colors.selectcolor      = {150/256, 0, 0, 1} -- Background color selection
+    self.colors.selecttext       = {1/256*255, 1/256*221, 1/256*0, 1} -- Foreground color selection
+    self.colors.textcolor        = {51/256, 68/256, 255/256, 1} -- pattern data text color (only used when normal and bar are left undefined)
+    -- note color
+    self.colors.textcolorbar     = {51/256, 68/256, 255/256, 1} -- pattern data text color at bar (only used when normal and bar are left undefined)
+
+    -- yellow header, color from protracker of course :)
+    self.colors.headercolor      = protracker_yellow -- column headers, statusbar etc
+--      self.colors.inactive         = {115/256, 115/256, 115/256, 1} -- column headers, statusbar etc
+
+    self.colors.linecolor        = {0/256, 0/256, 0/256, 1} -- normal row
+    self.colors.linecolor2       = {1/256, 1/256, 1/256, 0.6} -- beats (must not have 100% alpha as it's drawn over the cursor(!)) lines 2 3 4 excluding first line per beat
+--      self.colors.linecolor3       = {1/256*180, 1/256*148, 1/256*120, 1} -- scroll indicating trangle thingy
+    self.colors.linecolor4       = {0/256, 0/256, 0/256, 1} -- Reaper edit cursor, I make it invisible meaning black as I can not see any value in this line for now
+    self.colors.linecolor5       = {0/256, 0/256, 0/256, 1.0} -- Bar start, each beat color meaning each 4 lines in my case at least
+
+--      self.colors.loopcolor        = {1/256*204, 1/256*204, 1/256*68, 1} -- lines surrounding loop
+    self.colors.copypaste        = {1/256*57, 1/256*57, 1/256*20, 0.66}  -- the selection (should be lighter (not alpha blended) but is drawn over the data)
+
+--      self.colors.scrollbar1       = {98/256, 98/256, 98/256, 1} -- scrollbar handle & outline
+    self.colors.scrollbar1       = protracker_blue -- scrollbar handle & outline
+    self.colors.scrollbar2       = {0, 0, 0, 1} -- scrollbar background
+
+    self.colors.changed          = {1, 1, 0, 1}  -- Color indicating a changed but uncommitted setting
+    self.colors.changed2         = {0, .5, 1, .5} -- Only listening
+
+    -- background, where no notes are
+    self.colors.windowbackground = {0/256, 0/256, 0/256, 1}  -- Window background. Note that the alpha channel is ignored.
+    self.colors.crtStrength      = 0  -- How strong should the CRT effect be when enabled.
+    
+    -- Colors that override the text colors for different columns
+    -- When these are specified, the colors textcolor and textcolorbar are ignored.
+--      self.colors.normal.mod1      = {243/255, 171/255, 116/255, 1.0}
+--      self.colors.normal.mod2      = self.colors.normal.mod1
+--      self.colors.normal.mod3      = self.colors.normal.mod1
+--      self.colors.normal.mod4      = self.colors.normal.mod1
+    self.colors.normal.modtxt1   = protracker_blue
+    self.colors.normal.modtxt2   = protracker_blue
+    self.colors.normal.modtxt3   = protracker_blue
+    self.colors.normal.modtxt4   = protracker_blue
+    self.colors.normal.vel1      = protracker_blue
+    self.colors.normal.vel2      = protracker_blue
+    self.colors.normal.delay1    = protracker_blue
+    self.colors.normal.delay2    = protracker_blue
+    self.colors.normal.fx1       = protracker_blue
+    self.colors.normal.fx2       = protracker_blue
+    self.colors.normal.end1      = protracker_blue
+    self.colors.normal.end2      = protracker_blue
+    
+    self.colors.bar.mod1         = protracker_blue
+    self.colors.bar.mod2         = protracker_blue
+    self.colors.bar.mod3         = protracker_blue
+    self.colors.bar.mod4         = protracker_blue
+    
+    self.colors.bar.modtxt1      = protracker_blue
+    self.colors.bar.modtxt2      = protracker_blue
+    self.colors.bar.modtxt3      = protracker_blue
+    self.colors.bar.modtxt4      = protracker_blue
+    self.colors.bar.vel1         = protracker_blue
+    self.colors.bar.vel2         = protracker_blue
+    self.colors.bar.delay1       = protracker_blue
+    self.colors.bar.delay2       = protracker_blue
+    self.colors.bar.fx1          = protracker_blue
+    self.colors.bar.fx2          = protracker_blue
+    self.colors.bar.end1         = protracker_blue
+    self.colors.bar.end2         = protracker_blue
+    
+    self.colors.patternFont         = "Fruity microfont"  -- Custom font. Note that it should be installed on the system.
+    self.colors.patternFontSize     = tracker.cfg.fontSize or 14  -- Font size. Usually overridden by the user already.
+    self.colors.customFontDisplace  = { self.colors.patternFontSize-6, -3 }  -- Font displacement to fixup alignment issues.
   else
     -- Custom color scheme
     if extraThemes[colorScheme] then

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -3353,6 +3353,57 @@ function tracker:customFieldDescription()
   end
 end
 
+function drawPattern(colors, data, scrolly, rows, sig, zeroindexed, xloc, yloc, yheight, yshift, itempadx, itempady, tw, extraFontShift, indicatorShiftX, dlink, xlink)
+  local gfx = gfx
+  local c1, c2, tx, fc
+  for y=1,#yloc do
+    local absy = y + scrolly
+    if ( absy > 0 and absy <= rows ) then
+      if ( (((absy-1)/sig) - math.floor((absy-1)/sig)) == 0 ) then
+        c1 = colors.linecolor5
+        c2 = colors.linecolor5s
+        tx = colors.textcolorbar or colors.textcolor
+        fc = colors.bar
+      elseif ( (((absy-1)/(.25*sig)) - math.floor((absy-1)/(.25*sig))) == 0 ) then
+        c1 = colors.linecolor2
+        c2 = colors.linecolor2s
+        tx = colors.textcolorbar or colors.textcolor
+        fc = colors.bar
+      else
+        c1 = colors.linecolor
+        c2 = colors.linecolors
+        tx = colors.textcolor
+        fc = colors.normal
+      end
+
+      gfx.y = yloc[y] + extraFontShift
+      gfx.x = xloc[1] - indicatorShiftX
+
+      gfx.set(table.unpack(tx))
+      if zeroindexed == 1 then
+        gfx.printf("%03d", absy-1)
+      else
+        gfx.printf("%03d", absy)
+      end
+      gfx.set(table.unpack(c1))
+      gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, tw, yheight[1] + itempady)
+      gfx.set(table.unpack(c2))
+      gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, tw, 1)
+      gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, 1, yheight[y])
+      gfx.rect(xloc[1] - itempadx + tw + 0, yloc[y] - yshift, 1, yheight[y] + itempady)
+
+      for x=1,#xloc do
+        local thisfield = dlink[x]
+        gfx.x = xloc[x]
+        gfx.set(table.unpack(fc[thisfield] or tx))
+
+        local cdata = data[thisfield][rows*xlink[x]+absy-1]
+        writeField( cdata, ellipsis, xloc[x], yloc[y], customFont )
+      end
+    end
+  end
+end
+
 ------------------------------
 -- Draw the GUI
 ------------------------------
@@ -3417,58 +3468,13 @@ function tracker:renderGUI()
   end
 
   if ( self.take ) then
-    for y=1,#yloc do
-      local absy = y + scrolly
-      if ( absy > 0 and absy <= rows ) then
-        local c1, c2, tx, fc
-        if ( (((absy-1)/sig) - math.floor((absy-1)/sig)) == 0 ) then
-          c1 = colors.linecolor5
-          c2 = colors.linecolor5s
-          tx = colors.textcolorbar or colors.textcolor
-          fc = colors.bar
-        elseif ( (((absy-1)/(.25*sig)) - math.floor((absy-1)/(.25*sig))) == 0 ) then
-          c1 = colors.linecolor2
-          c2 = colors.linecolor2s
-          tx = colors.textcolorbar or colors.textcolor
-          fc = colors.bar
-        else
-          c1 = colors.linecolor
-          c2 = colors.linecolors
-          tx = colors.textcolor
-          fc = colors.normal
-        end
-
-        gfx.y = yloc[y] + extraFontShift
-        gfx.x = xloc[1] - plotData.indicatorShiftX
-
-        gfx.set(table.unpack(tx))
-        if tracker.zeroindexed == 1 then
-          gfx.printf("%03d", absy-1)
-        else
-          gfx.printf("%03d", absy)
-        end
-        gfx.set(table.unpack(c1))
-        gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, tw, yheight[1] + itempady)
-        gfx.set(table.unpack(c2))
-        gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, tw, 1)
-        gfx.rect(xloc[1] - itempadx, yloc[y] - yshift, 1, yheight[y])
-        gfx.rect(xloc[1] - itempadx + tw + 0, yloc[y] - yshift, 1, yheight[y] + itempady)
-
-        for x=1,#xloc do
-          local thisfield = dlink[x]
-          gfx.x = xloc[x]
-          gfx.set(table.unpack(fc[thisfield] or tx))
-
-          local cdata = data[thisfield][rows*xlink[x]+absy-1]
-          writeField( cdata, ellipsis, xloc[x], yloc[y], customFont )
-        end
-      end
-    end
+    drawPattern(colors, data, scrolly, rows, sig, tracker.zeroindexed, xloc, yloc, yheight, yshift, itempadx, itempady, tw, extraFontShift, plotData.indicatorShiftX, dlink, xlink)
   
+    -- Selector
     if ( xloc[relx] and yloc[rely] ) then
       local absy = rely + scrolly
       gfx.set(table.unpack(colors.selectcolor))
-      gfx.rect(xloc[relx]-1, yloc[rely]-plotData.yshift, xwidth[relx], yheight[rely] + itempady)
+      gfx.rect(xloc[relx]-1, yloc[rely] - yshift, xwidth[relx], yheight[rely] + itempady)
     
       gfx.x = xloc[relx]
       gfx.y = yloc[rely]

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -3357,6 +3357,8 @@ end
 -- Draw the GUI
 ------------------------------
 function tracker:renderGUI()
+  local start_time = os.clock()
+
   local ellipsis  = self.colors.ellipsis
   local tracker   = tracker
   local colors    = tracker.colors
@@ -3462,16 +3464,16 @@ function tracker:renderGUI()
         end
       end
     end
-
+  
     if ( xloc[relx] and yloc[rely] ) then
       local absy = rely + scrolly
       gfx.set(table.unpack(colors.selectcolor))
       gfx.rect(xloc[relx]-1, yloc[rely]-plotData.yshift, xwidth[relx], yheight[rely] + itempady)
-
+    
       gfx.x = xloc[relx]
       gfx.y = yloc[rely]
       gfx.set(table.unpack(colors.selecttext or colors.textcolor))
-
+    
       local cdata = data[dlink[relx]][rows*xlink[relx]+absy-1]
       writeField( cdata, ellipsis, xloc[relx], yloc[rely], customFont )
     end
@@ -4001,6 +4003,12 @@ function tracker:renderGUI()
       gfx.line(c, 0, c, gfx.h)
     end
   end
+  
+  gfx.x = 0
+  gfx.y = 0
+  local current_time = os.clock() - start_time
+  self.time = 0.95 * (self.time or current_time) + 0.05 * current_time
+  gfx.printf("%f", 1000 * self.time)
 end
 
 -- Load the scales

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -51,6 +51,7 @@
   + Add some commented out functions used for profiling stuff.
   + Fix nil bug when simulating.
   + Rename render function.
+  + Change OFC to OFF in pattern data.
  * v3.09 (2022-11-24)
   + Improve layout logic.
   + Add scrollbar to options.
@@ -5862,7 +5863,7 @@ function tracker:assignOFF(channel, idx)
 
   local ppq = table.unpack( txtList[idx] )
   local row = math.floor( ppq * self.rowPerPpq )
-  data.text[rows*channel + row] = 'OFC'
+  data.text[rows*channel + row] = 'OFF'
   data.note[rows*channel + row] = -idx - 2
 end
 


### PR DESCRIPTION
PR adds the following:
- `TonE` theme (protracker style contributed by `TonE`, relies on the free font `fruity microfont` being installed
- Splits input handling out of main loop and localized the keys in a closure with it.
- Rename the `OFC` that occurs when adding a note off after an existing note off to `OFF` to reduce confusion.
- Adds a very basic frame time counter (optional).
- Improves performance by not rerendering the complete pattern data every time but rendering it onto an offscreen buffer every time it changes, and just blitting that instead.
- Fixes a crash bug that could occur when animated backgrounds were active and the window was resized.
- Slightly refactor render function.