### PR TITLE
tracker : fix tabbing in sampler mode

### DIFF
--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -2470,7 +2470,7 @@ function tracker:linkCC_channel(modmode, ch, data, master, datafield, idx, colsi
 
     if ( modtypes ) then
       for j = 1,#modtypes do
-        master[#master+1]       = 1
+        master[#master+1]       = 0
         datafield[#datafield+1] = 'modtxt1'
         idx[#idx+1]             = idxes[j]
         colsizes[#colsizes+1]   = 1


### PR DESCRIPTION
When using Hackey_Sample_Playback, the "Tab" key does not advance correctly to the next note column. This also impacts entering chords using shift. The problem seems to be the "master" status of the first mod column per track. This fixes that.