### PR TITLE
Bug fixes to retrigger

### DIFF
--- a/Tracker/Hackey_Sample_Playback.jsfx
+++ b/Tracker/Hackey_Sample_Playback.jsfx
@@ -597,7 +597,7 @@ local(vol_change,
     vol_change = (1.0 - floor(effect_value / 16) / 8);
     count = effect_value % 16;
     dt = floor(samples_per_beat / (count + 1));
-    cv = vol;
+    cv = vol * vol_change;
     loop(count,
       note_schedule_ptr[] = dt; note_schedule_ptr += 1;
       note_schedule_ptr[] = cv; note_schedule_ptr += 1; // Volume
@@ -694,8 +694,8 @@ global(N_SAMPLES, select_by_notes)
 );
 
 function processBacklog()
-instance(note_schedule, note_schedule_ptr, next_backlog)
-local(chan, vol, sample_idx)
+instance(note_schedule, note_schedule_ptr, next_backlog, vol)
+local(sample_idx)
 global()
 (
   // Count down to the next item

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -3534,7 +3534,7 @@ function tracker:customFieldDescription()
         end
         return string.format("Arpeggiate (%s, %s semitones)", to_txt(math.floor(cc_level/16)), to_txt(cc_level % 16))
       elseif cc_value == 11 then
-        return string.format("Retrigger (Vol: %d %%, Count: %d)", math.floor(100 - 100*cc_level/16/8), ((cc_level % 16)))
+        return string.format("Retrigger (Vol: %d %%, Count: %d)", math.floor(100 - 100*math.floor(cc_level/16)/8), ((cc_level % 16)))
       elseif cc_value == 12 then
         return string.format("Sample probability (%d %%)", math.floor(100 * (cc_level / 127)))
       elseif cc_value == 96 then


### PR DESCRIPTION
This fixes a couple of minor bugs which were stopping the retrigger volume decay from working properly:

- Most importantly, the volume change for the sampler retrigger command was not working because `vol` was declared as a local variable in `processBacklog`.

- More a niggle, but the % readout in the status line for the effect was also not quite right; this fixes this.

- Finally, to my mind, if the volume change for the retrigger is <100%, then the first retrigger should have that scaling applied, rather than the first retrigger being at the same volume as the original note. I implemented this.