### PR TITLE
sampler: fix play position in large view

### DIFF
--- a/Tracker/Hackey_Sample_Playback.jsfx
+++ b/Tracker/Hackey_Sample_Playback.jsfx
@@ -1,9 +1,9 @@
 noindex: true
 desc:Hackey Trackey Sample Playback Module (pre-alpha)
 tags: tracker-style sampler
-version: 0.71
+version: 0.72
 author: Joep Vanlier
-changelog: Volume ramps immediately to current channel volume at note-on
+changelog: Fix play position indicator in the waveform editing window when zoomed in.
 license: MIT
 about:
   # Hackey Tracker Sampler
@@ -1042,11 +1042,13 @@ updated_loop ? (
 /* Zoomed in waveform */
 close_up.draw_sample_big(gfx_pad, cy, gfx_w - 2 * gfx_pad, sample_edit_size, reset_zoom);
 
-function draw_playmarker(sample_idx, rel_pos)
-local(x_pos, y_pos)
+function draw_playmarker(sample_idx, pos, sample_len)
+local(x_pos, y_pos, rel_pos, rel_pos_big)
 global(nx, ny, gfx_pad, block_pad, block_width, block_height,
-       selected_sample, cy, gfx_w, gfx_pad, sample_edit_size)
+       selected_sample, cy, gfx_w, gfx_pad, sample_edit_size,
+       close_up.disp_range_start, close_up.disp_range_len, close_up.sample_start)
 (
+  rel_pos = pos / sample_len;
   y_pos = floor(sample_idx / nx);
   x_pos = sample_idx - y_pos * nx;
   
@@ -1063,10 +1065,11 @@ global(nx, ny, gfx_pad, block_pad, block_width, block_height,
   selected_sample == sample_idx ? (
     x_pos = gfx_pad;
     y_pos = cy;
+    rel_pos_big = (pos - (close_up.disp_range_start - close_up.sample_start)) / close_up.disp_range_len;
     gfx_set(.3, .5, 1, .33);
-    gfx_rect(x_pos + rel_pos * (gfx_w - 2 * gfx_pad) - 1, y_pos, 3, sample_edit_size);
+    gfx_rect(x_pos + rel_pos_big * (gfx_w - 2 * gfx_pad) - 1, y_pos, 3, sample_edit_size);
     gfx_set(.5, .5, 1, 1);
-    gfx_rect(x_pos + rel_pos * (gfx_w - 2 * gfx_pad), y_pos, 1, sample_edit_size);
+    gfx_rect(x_pos + rel_pos_big * (gfx_w - 2 * gfx_pad), y_pos, 1, sample_edit_size);
   );
 );
 
@@ -1077,11 +1080,11 @@ instance(sample_idx, current_playback, play0, play1)
 (
   (current_playback == 0) ? (
     play0.playing && (play0.position > 0) ? (
-      draw_playmarker(sample_idx, 2 * play0.position / samplelocs[sample_idx][]);
+      draw_playmarker(sample_idx, 2 * play0.position, samplelocs[sample_idx][]);
     );
   ) : (
     play1.playing && (play1.position > 0) ? (
-      draw_playmarker(sample_idx, 2 * play1.position / samplelocs[sample_idx][]);      
+      draw_playmarker(sample_idx, 2 * play1.position, samplelocs[sample_idx][]);
     );
   );
 );

--- a/Tracker/tracker.lua
+++ b/Tracker/tracker.lua
@@ -14,7 +14,7 @@
 @links
   https://github.com/joepvanlier/Hackey-Trackey
 @license MIT
-@version 3.38
+@version 3.39
 @screenshot https://i.imgur.com/c68YjMd.png
 @about
   ### Hackey-Trackey
@@ -47,6 +47,9 @@
 
 --[[
  * Changelog:
+ * v3.39 (2026-03-30)
+  + Sampler: Fixed issue where when notes are played in the sampler, they immediately start at the correct velocity and pan, skipping the 15ms ramp. Changes of volume during playback are still ramped (thanks rhgg2!).
+  + Sampler: Fixed issue where the play position didn't correctly take into account the zoom state for the waveform preview.
  * v3.38 (2026-03-29)
   + Bind shift-left click the same as right-click (thanks rhgg2!).
   + Highlight bars as well as beats (thanks rhgg2!).
@@ -713,7 +716,7 @@
 -- gfx = dofile(reaper.GetResourcePath() .. '/Scripts/ReaTeam Extensions/API/gfx2imgui.lua')
 
 tracker = {}
-tracker.name = "Hackey Trackey v3.36"
+tracker.name = "Hackey Trackey v3.39"
 
 tracker.configFile = "_hackey_trackey_options_.cfg"
 tracker.keyFile = "userkeys.lua"

--- a/index.xml
+++ b/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<index version="1" name="Tracker tools" commit="9372ed9146e1262f7d86bec50880c2b531f46658">
+<index version="1" name="Tracker tools" commit="5b487ac40401759982563d593f344456c646ad8b">
   <category name="Tracker">
     <reapack name="tracker.lua" type="script" desc="Hackey-Trackey: A tracker interface similar to Jeskola Buzz for MIDI and FX editing.">
       <metadata>
@@ -1800,6 +1800,17 @@ FF = the full length of the last tick.]]></changelog>
         <source type="effect" file="htp_midi.jsfx-inc">https://github.com/JoepVanlier/Hackey-Trackey/raw/9372ed9146e1262f7d86bec50880c2b531f46658/Tracker/htp_midi.jsfx-inc</source>
         <source type="effect" file="htp_sample_editor.jsfx-inc">https://github.com/JoepVanlier/Hackey-Trackey/raw/9372ed9146e1262f7d86bec50880c2b531f46658/Tracker/htp_sample_editor.jsfx-inc</source>
         <source type="effect" file="Hackey Trackey Channel Cycler.jsfx">https://github.com/JoepVanlier/Hackey-Trackey/raw/9372ed9146e1262f7d86bec50880c2b531f46658/Tracker/Hackey%20Trackey%20Channel%20Cycler.jsfx</source>
+      </version>
+      <version name="3.39" author=": Joep Vanlier" time="2026-03-30T18:48:41Z">
+        <source file="scales.lua">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/scales.lua</source>
+        <source main="main">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/tracker.lua</source>
+        <source main="main" file="hackey_trackey_tracker.lua">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/hackey_trackey_tracker.lua</source>
+        <source main="main" file="hackey_trackey_load_sample.lua">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/hackey_trackey_load_sample.lua</source>
+        <source type="effect" file="Hackey_MIDI_Detector.jsfx">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/Hackey_MIDI_Detector.jsfx</source>
+        <source type="effect" file="Hackey_Sample_Playback.jsfx">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/Hackey_Sample_Playback.jsfx</source>
+        <source type="effect" file="htp_midi.jsfx-inc">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/htp_midi.jsfx-inc</source>
+        <source type="effect" file="htp_sample_editor.jsfx-inc">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/htp_sample_editor.jsfx-inc</source>
+        <source type="effect" file="Hackey Trackey Channel Cycler.jsfx">https://github.com/JoepVanlier/Hackey-Trackey/raw/5b487ac40401759982563d593f344456c646ad8b/Tracker/Hackey%20Trackey%20Channel%20Cycler.jsfx</source>
       </version>
     </reapack>
   </category>


### PR DESCRIPTION
play position didn't take into account the zoom state of the wave preview, this fixes that